### PR TITLE
update footer

### DIFF
--- a/src/pug/inc/components/_footer.pug
+++ b/src/pug/inc/components/_footer.pug
@@ -1,2 +1,19 @@
 footer.footer
-  .container フッターが入ります。
+  .container
+    p.footer__logo LOGO
+    .footer-info
+      .footer-link
+        -
+          var children = [
+            {
+              'label': 'プライバシーポリシー',
+              'url': 'https://google.com'
+            },
+            {
+              'label': '利用規約',
+              'url': 'https://google.com'
+            },
+          ];
+        each child in children
+          a.footer-link__child #{child.label}
+      .footer-copyright &copy; 2021 xxxxx.

--- a/src/scss/components/_footer.scss
+++ b/src/scss/components/_footer.scss
@@ -33,3 +33,18 @@
     justify-content: space-between;
   }
 }
+
+.footer-link {
+  display: inline-block;
+  margin-bottom: 8px;
+
+  &__child {
+    &:not(:last-of-type) {
+      margin-right: 8px;
+    }
+  }
+
+  @include mixins.md {
+    margin-bottom: 0px;
+  }
+}

--- a/src/scss/components/_footer.scss
+++ b/src/scss/components/_footer.scss
@@ -1,8 +1,35 @@
 @use '../config/variables';
+@use '../config/mixins';
 
 .footer {
-  padding-top: 120px;
-  padding-bottom: 120px;
+  padding-top: 30px;
+  padding-bottom: 40px;
   background-color: variables.$color-text;
   color: #fff;
+
+  @include mixins.md {
+    padding-top: 40px;
+    padding-bottom: 60px;
+  }
+
+  &__logo {
+    font-family: variables.$font-rounded;
+    font-size: 32px;
+    font-weight: 900;
+    letter-spacing: 1.28px;
+    opacity: 1;
+  }
+}
+
+.footer-info {
+  margin-top: 24px;
+  display: flex;
+  flex-direction: column;
+  font-size: 14px;
+  color: #ccc;
+
+  @include mixins.md {
+    flex-direction: row;
+    justify-content: space-between;
+  }
 }

--- a/src/scss/components/_footer.scss
+++ b/src/scss/components/_footer.scss
@@ -35,7 +35,6 @@
 }
 
 .footer-link {
-  display: inline-block;
   margin-bottom: 8px;
 
   &__child {


### PR DESCRIPTION
#8 の対応です。

デザインカンプの「プライバシーポリシー　利用規約」は1つの要素になってますが、
本来は個別の要素ですよね？
実装は配列で個別にしましたが、間のスペースが入らずに困っています。
PCの横の場合は、Childに`margin-right: 8px`入れればと思いまいたが、効かずでした。
スマホも縦に少し空けたいです。

スマホ画面は、カンプがないため、どうしてもこれでいいのかはっきりとした正解が分かりません。
レビューも困るのではないかなと思います・・・w
